### PR TITLE
Adding support for pagination on the related models

### DIFF
--- a/papertrail/templates/admin/change_form.html
+++ b/papertrail/templates/admin/change_form.html
@@ -1,4 +1,4 @@
-{% extends 'admin:admin/change_form.html' %}
+{% extends 'admin/change_form.html' %}
 {% load i18n admin_urls papertrail %}
 
 {% block object-tools-items %}

--- a/papertrail/templates/admin/object_papertrail.html
+++ b/papertrail/templates/admin/object_papertrail.html
@@ -101,20 +101,24 @@
         </div>
     </div>
 
+    {% block pagination %}
     <div class="pagination">
         <span class="step-links">
             {% if action_list.has_previous %}
-                <a href="?page={{ action_list.previous_page_number }}">previous</a>
+                <a href="?page={{ action_list.previous_page_number }}">{%  trans "previous" %}</a>
             {% endif %}
 
             <span class="current">
-                Page {{ action_list.number }} of {{ action_list.paginator.num_pages }}.
+                {%  blocktrans with page=action_list.number num_pages=action_list.paginator.num_pages %}
+                    Page {{ page }} of {{ num_pages }}.
+                {%  endblocktrans %}
             </span>
 
             {% if action_list.has_next %}
-                <a href="?page={{ action_list.next_page_number }}">next</a>
+                <a href="?page={{ action_list.next_page_number }}">{%  trans "next" %}</a>
             {% endif %}
 
         </span>
     </div>
+    {% endblock %}
 {% endblock %}

--- a/papertrail/templates/admin/object_papertrail.html
+++ b/papertrail/templates/admin/object_papertrail.html
@@ -100,4 +100,21 @@
             {% endif %}
         </div>
     </div>
+
+    <div class="pagination">
+        <span class="step-links">
+            {% if action_list.has_previous %}
+                <a href="?page={{ action_list.previous_page_number }}">previous</a>
+            {% endif %}
+
+            <span class="current">
+                Page {{ action_list.number }} of {{ action_list.paginator.num_pages }}.
+            </span>
+
+            {% if action_list.has_next %}
+                <a href="?page={{ action_list.next_page_number }}">next</a>
+            {% endif %}
+
+        </span>
+    </div>
 {% endblock %}

--- a/test_site/requirements.txt
+++ b/test_site/requirements.txt
@@ -1,0 +1,2 @@
+django
+jsonfield

--- a/test_site/test_app/admin.py
+++ b/test_site/test_app/admin.py
@@ -1,3 +1,9 @@
 from django.contrib import admin
 
-# Register your models here.
+from papertrail.admin import AdminEventLoggerMixin
+from .models import Simple
+
+
+@admin.register(Simple)
+class SimpleAdmin(AdminEventLoggerMixin, admin.ModelAdmin):
+    list_per_page = 5

--- a/test_site/test_app/models.py
+++ b/test_site/test_app/models.py
@@ -1,3 +1,8 @@
 from django.db import models
 
 # Create your models here.
+
+
+class Simple(models.Model):
+    name = models.CharField(max_length=200, blank=False, null=False)
+    version = models.IntegerField

--- a/test_site/test_site/settings.py
+++ b/test_site/test_site/settings.py
@@ -25,12 +25,13 @@ SECRET_KEY = '0%te(_0m&$gr#4#1_&2_%d_mc2+-t11s*&1w-dk_cg-zo1_zqp'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["localhost"]
 
 
 # Application definition
 
 INSTALLED_APPS = [
+    'papertrail',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -38,7 +39,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'test_app',
-    'papertrail',
 ]
 
 MIDDLEWARE = [
@@ -55,18 +55,22 @@ ROOT_URLCONF = 'test_site.urls'
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [os.path.join(BASE_DIR, "../../templates")],
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
+            "loaders": [
+                "django.template.loaders.filesystem.Loader",
+                "django.template.loaders.app_directories.Loader",
+            ],
+            "string_if_invalid": '<< MISSING VARIABLE "%s" >>' if DEBUG else "",
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = 'test_site.wsgi.application'
@@ -77,12 +81,8 @@ WSGI_APPLICATION = 'test_site.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'papertrail-test',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': 'localhost',
-        'PORT': '5432',
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'mydatabase',
     }
 }
 


### PR DESCRIPTION
When the same entry change many times the list of changes of that object wasn't paginated, thus the list grew massively and it wasn't that easy to use.

I made some changes to the test app so the added feature can be seen in an easier way.